### PR TITLE
Add settings option to show estimated token count, bump version to `0.1.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "chatbox",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chatbox",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
+        "@dqbd/tiktoken": "^0.4.0",
         "@electron-forge/maker-dmg": "^6.0.5",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
@@ -20,6 +21,7 @@
         "electron-store": "^8.1.0",
         "form-data": "^4.0.0",
         "github-markdown-css": "^5.2.0",
+        "gpt-3-encoder": "^1.1.4",
         "highlight.js": "^11.7.0",
         "markdown-it": "^13.0.1",
         "material-ui-popup-state": "^5.0.4",
@@ -219,6 +221,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@dqbd/tiktoken": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-0.4.0.tgz",
+      "integrity": "sha512-iaHgmwKAOqowBFZKxelyszoeGLoNw62eOULcmyme1aA1Ymr3JgYl0V7jwpuUm7fksalycZajx3loFn9TRUaviw=="
     },
     "node_modules/@electron-forge/cli": {
       "version": "6.0.5",
@@ -6698,6 +6705,11 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
+    "node_modules/gpt-3-encoder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
+      "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg=="
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -12723,6 +12735,11 @@
         }
       }
     },
+    "@dqbd/tiktoken": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-0.4.0.tgz",
+      "integrity": "sha512-iaHgmwKAOqowBFZKxelyszoeGLoNw62eOULcmyme1aA1Ymr3JgYl0V7jwpuUm7fksalycZajx3loFn9TRUaviw=="
+    },
     "@electron-forge/cli": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.0.5.tgz",
@@ -17336,6 +17353,11 @@
         "p-cancelable": "^2.0.0",
         "responselike": "^2.0.0"
       }
+    },
+    "gpt-3-encoder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
+      "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@dqbd/tiktoken": "^0.4.0",
         "@electron-forge/maker-dmg": "^6.0.5",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
@@ -22,6 +21,7 @@
         "form-data": "^4.0.0",
         "github-markdown-css": "^5.2.0",
         "gpt-3-encoder": "^1.1.4",
+        "gpt3-tokenizer": "^1.1.5",
         "highlight.js": "^11.7.0",
         "markdown-it": "^13.0.1",
         "material-ui-popup-state": "^5.0.4",
@@ -221,11 +221,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@dqbd/tiktoken": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-0.4.0.tgz",
-      "integrity": "sha512-iaHgmwKAOqowBFZKxelyszoeGLoNw62eOULcmyme1aA1Ymr3JgYl0V7jwpuUm7fksalycZajx3loFn9TRUaviw=="
     },
     "node_modules/@electron-forge/cli": {
       "version": "6.0.5",
@@ -2885,6 +2880,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-keyed-map": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/array-keyed-map/-/array-keyed-map-2.1.3.tgz",
+      "integrity": "sha512-JIUwuFakO+jHjxyp4YgSiKXSZeC0U+R1jR94bXWBcVlFRBycqXlb+kH9JHxBGcxnVuSqx5bnn0Qz9xtSeKOjiA=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -6709,6 +6709,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
       "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg=="
+    },
+    "node_modules/gpt3-tokenizer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/gpt3-tokenizer/-/gpt3-tokenizer-1.1.5.tgz",
+      "integrity": "sha512-O9iCL8MqGR0Oe9wTh0YftzIbysypNQmS5a5JG3cB3M4LMYjlAVvNnf8LUzVY9MrI7tj+YLY356uHtO2lLX2HpA==",
+      "dependencies": {
+        "array-keyed-map": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -12735,11 +12746,6 @@
         }
       }
     },
-    "@dqbd/tiktoken": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@dqbd/tiktoken/-/tiktoken-0.4.0.tgz",
-      "integrity": "sha512-iaHgmwKAOqowBFZKxelyszoeGLoNw62eOULcmyme1aA1Ymr3JgYl0V7jwpuUm7fksalycZajx3loFn9TRUaviw=="
-    },
     "@electron-forge/cli": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.0.5.tgz",
@@ -14639,6 +14645,11 @@
         "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       }
+    },
+    "array-keyed-map": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/array-keyed-map/-/array-keyed-map-2.1.3.tgz",
+      "integrity": "sha512-JIUwuFakO+jHjxyp4YgSiKXSZeC0U+R1jR94bXWBcVlFRBycqXlb+kH9JHxBGcxnVuSqx5bnn0Qz9xtSeKOjiA=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -17358,6 +17369,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
       "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg=="
+    },
+    "gpt3-tokenizer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/gpt3-tokenizer/-/gpt3-tokenizer-1.1.5.tgz",
+      "integrity": "sha512-O9iCL8MqGR0Oe9wTh0YftzIbysypNQmS5a5JG3cB3M4LMYjlAVvNnf8LUzVY9MrI7tj+YLY356uHtO2lLX2HpA==",
+      "requires": {
+        "array-keyed-map": "^2.1.3"
+      }
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatbox",
   "productName": "chatbox",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "cross-platform desktop client for OpenAI API",
   "main": ".webpack/main",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typescript": "~4.5.4"
   },
   "dependencies": {
+    "@dqbd/tiktoken": "^0.4.0",
     "@electron-forge/maker-dmg": "^6.0.5",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
@@ -60,6 +61,7 @@
     "electron-store": "^8.1.0",
     "form-data": "^4.0.0",
     "github-markdown-css": "^5.2.0",
+    "gpt-3-encoder": "^1.1.4",
     "highlight.js": "^11.7.0",
     "markdown-it": "^13.0.1",
     "material-ui-popup-state": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "typescript": "~4.5.4"
   },
   "dependencies": {
-    "@dqbd/tiktoken": "^0.4.0",
     "@electron-forge/maker-dmg": "^6.0.5",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
@@ -62,6 +61,7 @@
     "form-data": "^4.0.0",
     "github-markdown-css": "^5.2.0",
     "gpt-3-encoder": "^1.1.4",
+    "gpt3-tokenizer": "^1.1.5",
     "highlight.js": "^11.7.0",
     "markdown-it": "^13.0.1",
     "material-ui-popup-state": "^5.0.4",

--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -303,6 +303,7 @@ function App() {
                                 store.currentSession.messages.map((msg, ix) => (
                                     <Block id={msg.id} key={msg.id} msg={msg}
                                         showWordCount={store.settings.showWordCount}
+                                        showTokenCount={store.settings.showTokenCount}
                                         setMsg={(updated) => {
                                             store.currentSession.messages = store.currentSession.messages.map((m) => {
                                                 if (m.id === updated.id) {

--- a/src/devtools/Block.tsx
+++ b/src/devtools/Block.tsx
@@ -50,6 +50,7 @@ export interface Props {
     id?: string
     msg: Message
     showWordCount: boolean
+    showTokenCount: boolean
     setMsg: (msg: Message) => void
     delMsg: () => void
     refreshMsg: () => void
@@ -151,6 +152,13 @@ function _Block(props: Props) {
                                 {
                                     props.showWordCount && (
                                         <>word count: {wordCount.countWord(msg.content)}</>
+                                    )
+                                }
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary">
+                                {
+                                    props.showTokenCount && (
+                                        <>token estimate: {wordCount.estimateTokens(msg.content)}</>
                                     )
                                 }
                             </Typography>
@@ -273,5 +281,5 @@ const StyledMenu = styled((props: MenuProps) => (
 export default function Block(props: Props) {
     return useMemo(() => {
         return <_Block {...props} />
-    }, [props.msg, props.showWordCount])
+    }, [props.msg, props.showWordCount, props.showTokenCount])
 }

--- a/src/devtools/SettingWindow.tsx
+++ b/src/devtools/SettingWindow.tsx
@@ -85,6 +85,13 @@ export default function SettingWindow(props: Props) {
                     />
                 </FormGroup>
 
+                <FormGroup>
+                    <FormControlLabel control={<Switch />} label="Show estimated token count"
+                        checked={settingsEdit.showTokenCount}
+                        onChange={(e, checked) => setSettingsEdit({ ...settingsEdit, showTokenCount: checked })}
+                    />
+                </FormGroup>
+
             </DialogContent>
             <DialogActions>
                 <Button onClick={onCancel}>Cancel</Button>

--- a/src/devtools/store.ts
+++ b/src/devtools/store.ts
@@ -26,6 +26,7 @@ export function getDefaultSettings(): Settings {
         openaiKey: '',
         apiHost: 'https://api.openai.com',
         showWordCount: false,
+        showTokenCount: false,
     }
 }
 
@@ -40,6 +41,9 @@ export async function readSettings(): Promise<Settings> {
     }
     if (setting.showWordCount === undefined) {
         setting.showWordCount = getDefaultSettings().showWordCount
+    }
+    if (setting.showTokenCount === undefined) {
+        setting.showTokenCount = getDefaultSettings().showTokenCount
     }
     return setting
 }

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -31,4 +31,5 @@ export interface Settings {
     openaiKey: string
     apiHost: string
     showWordCount?: boolean
+    showTokenCount?: boolean
 }

--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -23,3 +23,36 @@ export function countWord(data: string): number {
     }
     return count;
 };
+
+export type EstimationMethod = "average" | "words" | "chars" | "max" | "min";
+export function estimateTokens(text: string, method: EstimationMethod = "max"): number | string {
+    // method can be "average", "words", "chars", "max", "min", defaults to "max"
+    const wordCount: number = text.split(" ").length;
+    const charCount: number = text.length;
+    const tokensCountWordEst: number = wordCount / 0.75;
+    const tokensCountCharEst: number = charCount / 4.0;
+    let output: number = 0;
+
+    switch (method) {
+        case "average":
+            output = (tokensCountWordEst + tokensCountCharEst) / 2;
+            break;
+        case "words":
+            output = tokensCountWordEst;
+            break;
+        case "chars":
+            output = tokensCountCharEst;
+            break;
+        case "max":
+            output = Math.max(tokensCountWordEst, tokensCountCharEst);
+            break;
+        case "min":
+            output = Math.min(tokensCountWordEst, tokensCountCharEst);
+            break;
+        default:
+            // return invalid method message
+            return "Invalid method. Use 'average', 'words', 'chars', 'max', or 'min'.";
+    }
+
+    return Math.ceil(output);
+}

--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -24,10 +24,9 @@ export function countWord(data: string): number {
     return count;
 };
 
-import { encoding_for_model } from "@dqbd/tiktoken";
-const enc = encoding_for_model("text-davinci-003");
-export function estimateTokens(text: string): number | string {
-    const encoded = enc.encode(text);
-    return encoded.length;
+import GPT3Tokenizer from 'gpt3-tokenizer';
+const tokenizer = new GPT3Tokenizer({ type: 'gpt3' });
+export function estimateTokens(str: string): number | string {
+    const encoded: { bpe: number[]; text: string[] } = tokenizer.encode(str);
+    return encoded.bpe.length;
 }
-

--- a/src/devtools/utils.ts
+++ b/src/devtools/utils.ts
@@ -24,35 +24,10 @@ export function countWord(data: string): number {
     return count;
 };
 
-export type EstimationMethod = "average" | "words" | "chars" | "max" | "min";
-export function estimateTokens(text: string, method: EstimationMethod = "max"): number | string {
-    // method can be "average", "words", "chars", "max", "min", defaults to "max"
-    const wordCount: number = text.split(" ").length;
-    const charCount: number = text.length;
-    const tokensCountWordEst: number = wordCount / 0.75;
-    const tokensCountCharEst: number = charCount / 4.0;
-    let output: number = 0;
-
-    switch (method) {
-        case "average":
-            output = (tokensCountWordEst + tokensCountCharEst) / 2;
-            break;
-        case "words":
-            output = tokensCountWordEst;
-            break;
-        case "chars":
-            output = tokensCountCharEst;
-            break;
-        case "max":
-            output = Math.max(tokensCountWordEst, tokensCountCharEst);
-            break;
-        case "min":
-            output = Math.min(tokensCountWordEst, tokensCountCharEst);
-            break;
-        default:
-            // return invalid method message
-            return "Invalid method. Use 'average', 'words', 'chars', 'max', or 'min'.";
-    }
-
-    return Math.ceil(output);
+import { encoding_for_model } from "@dqbd/tiktoken";
+const enc = encoding_for_model("text-davinci-003");
+export function estimateTokens(text: string): number | string {
+    const encoded = enc.encode(text);
+    return encoded.length;
 }
+


### PR DESCRIPTION
Hey hey! Thanks for the great work on this app, had a small improvement I wanted and figured I'd PR it :)

This PR:
- Adds a toggle in the settings page to enable showing estimated token count using https://github.com/botisan-ai/gpt3-tokenizer
- Sets version to `0.1.2` in `package.json`

<details>
<summary>Screenshot in App</summary>

![image](https://user-images.githubusercontent.com/1571956/225196959-2df5f8af-cb6d-4857-9134-645c5f666b55.png)
![image](https://user-images.githubusercontent.com/1571956/225486272-0a8931a7-9356-4d7b-82a2-6c59cb1da6cb.png)

</details>

<details>
<summary>OpenAPI Tokenizer Output:</summary>

![image](https://user-images.githubusercontent.com/1571956/225196874-6394a5b2-61ab-4764-9d28-3fc8cb03c52a.png)

</details>



