### PR TITLE
feat: support copy for code block

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ function Main() {
         // do copy
         // * thats lines copy from copy block content action
         navigator.clipboard.writeText(content);
-        store.addToast('Copied to clipboard');
+        store.addToast(t('copied to clipboard'));
     });
 
     // bind code block copy event on mounted

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,13 +91,16 @@ function Main() {
     const codeBlockCopyEvent = useRef((e: Event) => {
         const target: HTMLElement = e.target as HTMLElement;
 
+        const isCopyActionClassName = target.className === 'copy-action';
+        const isCodeBlockParent = target.parentElement?.className === 'code-block-wrapper';
+
         // check is copy action button
-        if (!((target.className === 'copy-action') && (target.parentNode?.nodeName === 'PRE'))) {
+        if (!(isCopyActionClassName && isCodeBlockParent)) {
             return;
         }
 
         // got codes
-        const content = target.parentNode.querySelector('code')?.innerText ?? '';
+        const content = target?.parentNode?.querySelector('code')?.innerText ?? '';
 
         // do copy
         // * thats lines copy from copy block content action

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -23,11 +23,13 @@ import * as wordCount from './utils'
 import FormatQuoteIcon from '@mui/icons-material/FormatQuote';
 import 'github-markdown-css/github-markdown-light.css'
 import mila from 'markdown-it-link-attributes';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, getI18n } from 'react-i18next';
 
 // copy button html content
 // join at markdown-it parsed
-const codeCopyButtonHTML = '<div class="copy-action">COPY</div>';
+const getCodeCopyButtonHTML = () => {
+    return `<div class="copy-action">${getI18n().t('copy')}</div>`;
+};
 
 const md = new MarkdownIt({
     linkify: true,
@@ -46,7 +48,7 @@ const md = new MarkdownIt({
         }
 
         // join actions html string
-        return `<pre class="hljs" style="position: relative; max-width: 50vw; overflow: auto">${codeCopyButtonHTML}<code>${content}</code></pre>`;
+        return `<pre class="hljs" style="position: relative; max-width: 50vw; overflow: auto">${getCodeCopyButtonHTML()}<code>${content}</code></pre>`;
     }
 });
 md.use(mdKatex, { blockClass: 'katexmath-block rounded-md p-[10px]', errorColor: ' #cc0000' })

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -49,10 +49,12 @@ const md = new MarkdownIt({
 
         // join actions html string
         return [
-            '<pre class="hljs" style="position: relative; max-width: 50vw; overflow: auto">',
+            '<div class="code-block-wrapper">',
             getCodeCopyButtonHTML(),
+            '<pre class="hljs" style="max-width: 50vw; overflow: auto">',
             `<code>${content}</code>`,
             '</pre>',
+            '</div>',
         ].join('');
     },
 });

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -48,9 +48,15 @@ const md = new MarkdownIt({
         }
 
         // join actions html string
-        return `<pre class="hljs" style="position: relative; max-width: 50vw; overflow: auto">${getCodeCopyButtonHTML()}<code>${content}</code></pre>`;
-    }
+        return [
+            '<pre class="hljs" style="position: relative; max-width: 50vw; overflow: auto">',
+            getCodeCopyButtonHTML(),
+            `<code>${content}</code>`,
+            '</pre>',
+        ].join('');
+    },
 });
+
 md.use(mdKatex, { blockClass: 'katexmath-block rounded-md p-[10px]', errorColor: ' #cc0000' })
 md.use(mila, { attrs: { target: "_blank", rel: "noopener" } })
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -72,13 +72,19 @@ code {
 }
 
 /* START of code block actions */
-.rendering .hljs div.copy-action {
+.code-block-wrapper {
+    position: relative;
+    max-width: 50vw;
+}
+
+.rendering .code-block-wrapper div.copy-action {
     display: none;
 }
 
-.hljs div.copy-action {
+.code-block-wrapper div.copy-action {
     position: absolute;
     right: 4px;
+    top: 2px;
     display: flex;
     line-height: 1;
     transition: all .3s;
@@ -91,7 +97,24 @@ code {
     padding: 4px;
 }
 
-.hljs:hover div.copy-action {
+
+html[data-theme='dark'] .code-block-wrapper div.copy-action {
+    background-color: rgba(144, 202, 249, 0.16);
+}
+
+html[data-theme='dark'] .code-block-wrapper div.copy-action:hover {
+    background-color: rgba(144, 202, 249, 0.36);
+}
+
+html[data-theme='light'] .code-block-wrapper div.copy-action {
+    background-color: rgba(25, 118, 210, 0.08);
+}
+
+html[data-theme='light'] .code-block-wrapper div.copy-action:hover {
+    background-color: rgba(25, 118, 210, 0.12);
+}
+
+.code-block-wrapper:hover div.copy-action {
     opacity: 1;
 }
 


### PR DESCRIPTION
Support for copying code block.
The copy button will be displayed when the code block is hovered over, and it supports i18n based on the latest branch.

![226849255-ec96e5c6-2a01-481f-8d8a-173335f1dd4b](https://user-images.githubusercontent.com/19162201/226974822-9f502ea1-ae4e-4be7-b139-b8dc76661719.png)
