### PR TITLE
chore: add target aarch64-apple-darwin, closes #120, #247

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        include:
+          - target: aarch64-apple-darwin
+            platform: macos-latest
+          - target: x86_64-apple-darwin
+            platform: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            platform: ubuntu-20.04
+          - target: x86_64-pc-windows-msvc
+            platform: windows-latest
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -73,3 +81,4 @@ jobs:
           releaseBody: 'See the assets to download this version and install.'
           releaseDraft: true
           prerelease: false
+          args: --target ${{matrix.target}}


### PR DESCRIPTION
在我的另一个项目中亲测可行：https://github.com/meowtec/LANSend/commit/ae32fa350443f5b679dd76ffb38471520ae65787

只是似乎 Apple 对 aarch 架构的包在安全性上要求更加严格，如果你的构建没有使用 Apple 开发者密钥进行签名，用户侧是不能直接打开的。（而  x86 版本则可以通过“右键 - 打开”的方式打开）
解决办法参考 https://github.com/meowtec/Imagine/issues/136