### PR TITLE
fix: delete session triggle switch session duplicate

### DIFF
--- a/src/SessionItem.tsx
+++ b/src/SessionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
     ListItemText, ListItemAvatar, MenuItem, Divider,
     Avatar, IconButton, Button, TextField, Popper, Fade, Typography, ListItemIcon,
@@ -13,8 +13,6 @@ import StyledMenu from './StyledMenu';
 import { useTranslation } from "react-i18next";
 import StarIcon from '@mui/icons-material/Star';
 import StarOutlineIcon from '@mui/icons-material/StarOutline';
-
-const { useState } = React
 
 export interface Props {
     session: Session
@@ -42,6 +40,7 @@ export default function SessionItem(props: Props) {
     };
 
     return (
+        <>
         <MenuItem
             key={session.id}
             selected={selected}
@@ -77,7 +76,8 @@ export default function SessionItem(props: Props) {
                     }
                 </IconButton>
             }
-            <StyledMenu
+        </MenuItem>
+        <StyledMenu
                 MenuListProps={{
                     'aria-labelledby': 'long-button',
                 }}
@@ -132,6 +132,6 @@ export default function SessionItem(props: Props) {
                 </MenuItem>
 
             </StyledMenu>
-        </MenuItem>
+        </>
     )
 }


### PR DESCRIPTION
Click delete menu the sessionItem, the session details on the right will not be updated, because it will trigger the onClick event of the menu one more time, which needs to be extracted to the outside can not be nested and used.

在左侧菜单点击删除会话，右边的会话详情不会更新，因为会多触发一次menu的onclick事件，需要提取到外边不能嵌套使用。

#369 