### PR TITLE
fix: input message should be trimmed before checking if it is empty.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -638,7 +638,7 @@ function MessageInput(props: {
     const { t } = useTranslation()
     const { messageInput, setMessageInput } = props
     const submit = (needGenerating = true) => {
-        if (messageInput.length === 0) {
+        if (messageInput.trim() === '') {
             return
         }
         props.onSubmit(createMessage('user', messageInput), needGenerating)


### PR DESCRIPTION
blank spaces shouldn't be allowed to submitted as messages. original logic only avoid 0-length messages, but  failed to stop  blank space messages. 

原来逻辑可以阻止用户不输入的情况下不能提交消息，但是用户输入空格之后，还是可以提交空格消息
