### PR TITLE
chore: add more URL pattern support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,8 @@ yarn-error.log*
 next-env.d.ts
 
 tmp
+
+#editor files
+.vscode/
+*.sublime-project
+*.sublime-workspace

--- a/src/packages/llm.ts
+++ b/src/packages/llm.ts
@@ -58,7 +58,7 @@ export async function chat(
     let fullText = ''
     try {
         const messages = prompts.map((msg) => ({ role: msg.role, content: msg.content }))
-        const response = await fetch(`${host}/v1/chat/completions`, {
+        const response = await fetch( new URL( '/v1/chat/completions', host ).href , {
             method: 'POST',
             headers: {
                 Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
1. add editor files to .gitignore
2. use URL API instead of template string to reach the full URL to make it more compatible Now it can support input API base URLs like 'http://api.chatanywhere.cn/v1' without manually exclude the suffix.