### PR TITLE
feat: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## what

- Add dependabot

## why

- Periodic dependency updates to increase security posture
- Note that `npm` covers both `yarn` and `npm` 
- Also note that dependabot will still need to be enabled on the repo in conjunction with this PR for it to propose PRs to update dependencies

## references
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file