### PR TITLE
fix: Japanese translation of `temperature`

### DIFF
--- a/src/renderer/i18n/locales/ja/translation.json
+++ b/src/renderer/i18n/locales/ja/translation.json
@@ -57,7 +57,7 @@
     "Roadmap": "ロードマップ",
     "FAQs": "よくある質問",
     "Changelog": "変更履歴",
-    "temperature": "テンプレート",
+    "temperature": "温度",
     "meticulous": "細心",
     "creative": "クリエイティブ",
     "Special thanks to the following sponsors:": "以下のスポンサーに特別な感謝を：",


### PR DESCRIPTION
### Description

Japanese translation of `temperature` was `テンプレート` but it means `template`.  This commit fixes it to `温度` (temperature).

### Additional Notes

### Screenshots

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

- [X] I have read and agree with the above statement.
