### PR TITLE
feat: Add Context Length Slider for Ollama Models

### DIFF
--- a/src/renderer/components/ContextLengthSlider.tsx
+++ b/src/renderer/components/ContextLengthSlider.tsx
@@ -1,0 +1,32 @@
+import { Box, Slider, Typography } from '@mui/material'
+
+interface Props {
+    value: number
+    onChange: (value: number) => void
+}
+
+export default function ContextLengthSlider({ value, onChange }: Props) {
+    const marks = [
+        { value: 8192, label: '8K' },
+        { value: 32768, label: '32K' },
+        { value: 65536, label: '64K' },
+        { value: 131072, label: '128K' },
+    ]
+
+    return (
+        <Box sx={{ width: '100%', paddingTop: '16px' }}>
+            <Typography gutterBottom>Context Length</Typography>
+            <Slider
+                value={value}
+                onChange={(_, newValue) => onChange(newValue as number)}
+                min={8192}
+                max={131072}
+                step={8192}
+                marks={marks}
+                valueLabelDisplay="auto"
+                valueLabelFormat={(value) => `${(value / 1024).toFixed(0)}K`}
+                aria-label="Context Length"
+            />
+        </Box>
+    )
+}

--- a/src/renderer/packages/models/ollama.ts
+++ b/src/renderer/packages/models/ollama.ts
@@ -9,6 +9,7 @@ interface Options {
     ollamaHost: string
     ollamaModel: string
     temperature: number
+    ollamaContextLength: number
 }
 
 export default class Ollama extends Base {
@@ -45,6 +46,7 @@ export default class Ollama extends Base {
                 stream: true,
                 options: {
                     temperature: this.options.temperature,
+                    num_ctx: this.options.ollamaContextLength
                 }
             },
             signal,

--- a/src/renderer/pages/SettingDialog/ModelSettingTab.tsx
+++ b/src/renderer/pages/SettingDialog/ModelSettingTab.tsx
@@ -9,6 +9,7 @@ import SiliconFlowSetting from './SiliconFlowSetting'
 import MaxContextMessageCountSlider from '@/components/MaxContextMessageCountSlider'
 import TemperatureSlider from '@/components/TemperatureSlider'
 import ClaudeSetting from './ClaudeSetting'
+import ContextLengthSlider from '@/components/ContextLengthSlider'
 
 interface ModelConfigProps {
     settingsEdit: ModelSettings
@@ -48,6 +49,10 @@ export default function ModelSettingTab(props: ModelConfigProps) {
                     <TemperatureSlider
                         value={settingsEdit.temperature}
                         onChange={(v) => setSettingsEdit({ ...settingsEdit, temperature: v })}
+                    />
+                    <ContextLengthSlider
+                        value={settingsEdit.ollamaContextLength}
+                        onChange={(v) => setSettingsEdit({ ...settingsEdit, ollamaContextLength: v })}
                     />
                 </>
             )}

--- a/src/renderer/pages/SettingDialog/OllamaSetting.tsx
+++ b/src/renderer/pages/SettingDialog/OllamaSetting.tsx
@@ -58,6 +58,7 @@ export function OllamaModelSelect(props: {
             ollamaHost: props.ollamaHost,
             ollamaModel: props.ollamaModel,
             temperature: 0.5,
+            ollamaContextLength: 8192,
         })
         model.listModels().then((models) => {
             setModels(models)

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -27,6 +27,7 @@ export function settings(): Settings {
 
         ollamaHost: 'http://127.0.0.1:11434',
         ollamaModel: '',
+        ollamaContextLength: 8192,
 
         lmStudioHost: 'http://127.0.0.1:1234',
         lmStudioModel: '',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -109,6 +109,7 @@ export interface ModelSettings {
     // ollama
     ollamaHost: string
     ollamaModel: string
+    ollamaContextLength: number
 
     // siliconflow
     siliconCloudHost: string


### PR DESCRIPTION
Add a new slider component to control the context length (num_ctx) parameter for Ollama models. This allows users to adjust the context window size between 8K and 128K tokens.

Changes:
- Add new ContextLengthSlider component with predefined marks at 8K, 32K, 64K, and 128K
- Update step size to 8K increments for better granularity control
- Add K-formatted value labels for better readability
- Update ModelSettings type to include ollamaContextLength
- Integrate context length control in ModelSettingTab
- Pass context length parameter to Ollama API calls

The context length parameter affects how much previous conversation history the model can access when generating responses. Larger values allow for longer memory but consume more RAM.

### Screenshots

<img width="592" alt="Screenshot 2025-01-29 at 20 56 09" src="https://github.com/user-attachments/assets/a3c7541d-770c-41ae-811e-6facd18d90be" />

`word count: 9476, token count: 15701, time: 20:02`
`word count: 945, token count: 1219, tokens used: 16922, model: Ollama (deepseek-r1:70b-llama-distill-q8_0), time: 20:08`

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[x] I have read and agree with the above statement.
