### PR TITLE
feature/When default prompt is empty, do not send a starter request.

### DIFF
--- a/src/renderer/stores/sessionActions.ts
+++ b/src/renderer/stores/sessionActions.ts
@@ -319,14 +319,10 @@ export function initEmptyChatSession(): Session {
         id: uuidv4(),
         name: 'Untitled',
         type: 'chat',
-        messages: [
-            {
-                id: uuidv4(),
-                role: 'system',
-                content: settings.defaultPrompt || defaults.getDefaultPrompt(),
-            },
-        ],
-    }
+        messages: settings.defaultPrompt 
+            ? [{ id: uuidv4(), role: 'system', content: settings.defaultPrompt }] 
+            : []
+    };
 }
 
 export function getSessions() {


### PR DESCRIPTION
### Description

When default prompt is set empty by user, do not send anything.

### Additional Notes

I dont know why its coded like this to begin with. There is already a reset button, if user wants the default prompt, user can always switch back to default settings.

### Screenshots

![image](https://github.com/user-attachments/assets/396e82c8-be8c-4eb8-ae41-cbf167a67283)

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[ X ] I have read and agree with the above statement.
