### PR TITLE
treak: ollama support ngrok in http request

### DIFF
--- a/src/renderer/packages/models/ollama.ts
+++ b/src/renderer/packages/models/ollama.ts
@@ -38,7 +38,10 @@ export default class Ollama extends Base {
         const messages = rawMessages.map(m => ({ role: m.role, content: m.content }))
         const res = await this.post(
             `${this.getHost()}/api/chat`,
-            { 'Content-Type': 'application/json' },
+            {
+                'Content-Type': 'application/json',
+                'ngrok-skip-browser-warning': '1',
+            },
             {
                 model: this.options.ollamaModel,
                 messages,
@@ -68,7 +71,7 @@ export default class Ollama extends Base {
     }
 
     async listModels(): Promise<string[]> {
-        const res = await this.get(`${this.getHost()}/api/tags`, {})
+        const res = await this.get(`${this.getHost()}/api/tags`, { 'ngrok-skip-browser-warning': '1', })
         const json = await res.json()
         if (! json['models']) {
             throw new ApiError(JSON.stringify(json))


### PR DESCRIPTION
### Description

Connecting to a ollama service exposed by ngrok would be block by lacking of ngrok-skip-browser-warning header.  This pr add ngrok-skip-browser-warning in each request header to fix the problem.

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[ ] I have read and agree with the above statement.
