### PR TITLE
Remove single tilde strikethrough

### DIFF
--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -24,7 +24,11 @@ export default function Markdown(props: {
     return useMemo(() => (
         <ReactMarkdown
             remarkPlugins={
-                [remarkGfm, remarkMath, remarkBreaks]
+                [
+                    [remarkGfm, { singleTilde: false }],  // Disable single tilde strikethrough
+                    remarkMath,
+                    remarkBreaks
+                ]
             }
             rehypePlugins={[rehypeKatex]}
             className={`break-words ${className || ''}`}
@@ -43,7 +47,7 @@ export default function Markdown(props: {
                 ),
             }}
         >
-            { children }
+            {children}
         </ReactMarkdown>
     ), [children])
 }


### PR DESCRIPTION
### Description

在 Markdown 渲染过程中，会对两个 `~` 包裹的内容应用删除线样式——在 LLM 输出内容中（尤其是角色扮演时），可能包含很多带有 `~` 的语气词——这使得出现很多这样语气词的时候，语气词中的 `~` 没有正常显示，反而在中间的文本上画出了删除线。实际上，LLM 在确实想要划去段落时使用的是 `~~`，而不是 `~`，所以可以去除关于单个 `~` 的渲染规则。

因此，对 `remarkGfm` 添加了 `{singleTilde: false}` 参数，使得单个 `~` 包裹的内容不会被应用删除线样式（而 `~~` 包裹的内容仍然会正常应用删除线样式）。

### Additional Notes

- `~` 包裹的内容不再被应用删除线样式：`喵呜~♡这就为您呈上暗夜女王的馈赠呦~` → 喵呜\~♡这就为您呈上暗夜女王的馈赠呦\~
- `~~` 包裹的内容仍然按照删除线样式渲染：`喵呜~~♡这就为您呈上暗夜女王的馈赠呦~~` → 喵呜~~♡这就为您呈上暗夜女王的馈赠呦~~

### Screenshots

Before: 
![图片](https://github.com/user-attachments/assets/5fe3d80b-600d-49b1-b4a0-0933f90e4bc9)

After:
![图片](https://github.com/user-attachments/assets/9c8ddbe2-efe5-4938-832d-5fbff167fda7)

### Contributor Agreement

By submitting this Pull Request, I confirm that I have read and agree to the following terms:

- I agree to contribute all code submitted in this PR to the open-source community edition licensed under GPLv3 and the proprietary official edition without compensation.
- I grant the official edition development team the rights to freely use, modify, and distribute this code, including for commercial purposes.
- I confirm that this code is my original work, or I have obtained the appropriate authorization from the copyright holder to submit this code under these terms.
- I understand that the submitted code will be publicly released under the GPLv3 license, and may also be used in the proprietary official edition.

Please check the box below to confirm:

[√] I have read and agree with the above statement.
